### PR TITLE
Add a LimitMax option

### DIFF
--- a/dist/gauge.coffee
+++ b/dist/gauge.coffee
@@ -239,7 +239,7 @@ class Gauge extends BaseGauge
 	displayedValue: 0
 	lineWidth: 40
 	paddingBottom: 0.1
-	percentColors: null
+	percentColors: null,
 	options:
 		colorStart: "#6fadcf"
 		colorStop: undefined
@@ -251,6 +251,7 @@ class Gauge extends BaseGauge
 		angle: 0.15
 		lineWidth: 0.44
 		fontSize: 40
+		limitMax: false
 		percentColors : [
 							[ 0.0, "#a9d70b" ],
 							[ 0.50, "#f9c802" ],
@@ -290,6 +291,7 @@ class Gauge extends BaseGauge
 				@percentColors[i] = { pct: @options.percentColors[i][0], color: { r: rval, g: gval, b: bval  } }
 
 	set: (value) ->
+
 		if not (value instanceof Array)
 			value = [value]
 		# check if we have enough GaugePointers initialized
@@ -300,13 +302,21 @@ class Gauge extends BaseGauge
 
 		# get max value and update pointer(s)
 		i = 0
+		max_hit = false
+
 		for val in value
 			if val > @maxValue
-				@maxValue = @value * 1.1
+					@maxValue = @value * 1.1
+					max_hit = true
 			@gp[i].value = val
 			@gp[i++].setOptions({maxValue: @maxValue, angle: @options.angle})
 		@value = value[value.length - 1] # TODO: Span maybe?? 
-		AnimationUpdater.run()
+
+		if max_hit
+			unless @options.limitMax
+				AnimationUpdater.run()
+		else
+			AnimationUpdater.run()
 
 	getAngle: (value) ->
 		return (1 + @options.angle) * Math.PI + ((value - @minValue) / (@maxValue - @minValue)) * (1 - @options.angle * 2) * Math.PI

--- a/dist/gauge.js
+++ b/dist/gauge.js
@@ -409,6 +409,7 @@
       angle: 0.15,
       lineWidth: 0.44,
       fontSize: 40,
+      limitMax: false,
       percentColors: [[0.0, "#a9d70b"], [0.50, "#f9c802"], [1.0, "#ff0000"]]
     };
 
@@ -469,7 +470,7 @@
     };
 
     Gauge.prototype.set = function(value) {
-      var i, val, _i, _j, _len, _ref;
+      var i, max_hit, val, _i, _j, _len, _ref;
       if (!(value instanceof Array)) {
         value = [value];
       }
@@ -479,10 +480,12 @@
         }
       }
       i = 0;
+      max_hit = false;
       for (_j = 0, _len = value.length; _j < _len; _j++) {
         val = value[_j];
         if (val > this.maxValue) {
           this.maxValue = this.value * 1.1;
+          max_hit = true;
         }
         this.gp[i].value = val;
         this.gp[i++].setOptions({
@@ -491,7 +494,13 @@
         });
       }
       this.value = value[value.length - 1];
-      return AnimationUpdater.run();
+      if (max_hit) {
+        if (!this.options.limitMax) {
+          return AnimationUpdater.run();
+        }
+      } else {
+        return AnimationUpdater.run();
+      }
     };
 
     Gauge.prototype.getAngle = function(value) {

--- a/index.html
+++ b/index.html
@@ -96,6 +96,8 @@ var opts = {
     strokeWidth: <span id="opt-pointer-strokeWidth" class="lit">0</span>, // The rotation offset
     color: '<span id="opt-pointer-color" class="lit">#000000</span>' // Fill color
   },
+  limitMax: '<span id="opt-limitMax" class="lit">false</span>',   // If true, the pointer will not go past the end of the gauge
+
   colorStart: '<span id="opt-colorStart" class="lit">0</span>',   // Colors
   colorStop: '<span id="opt-colorStop" class="lit">0</span>',    // just experiment with them
   strokeColor: '<span id="opt-strokeColor" class="lit">0</span>',   // to see which ones work best for you


### PR DESCRIPTION
I'm using this for a dashboard sales screen. In this particular use case, it records how many new registrations that haven't been dealt with before. I set the max value as 20 so the gauge  goes red when we start approaching that number.

If the number goes over the max (20) the dial starts being buggy and going backwards. I'm unsure of the need for this, but again there could be one so I left it be. However I added a 'limitMax' option that will basically stop animating the gauge with the set function if the value provided is more than the max value.
