### PR TITLE
Support for high-DPI displays

### DIFF
--- a/dist/gauge.coffee
+++ b/dist/gauge.coffee
@@ -113,6 +113,8 @@ class ValueUpdater
 		return false
 
 class BaseGauge extends ValueUpdater
+	displayScale: 1
+
 	setTextField: (textField) ->
 		@textField = if textField instanceof TextRenderer then textField else new TextRenderer(textField)
 
@@ -126,6 +128,34 @@ class BaseGauge extends ValueUpdater
 		@options = mergeObjects(@options, options)
 		if @textField
 			@textField.el.style.fontSize = options.fontSize + 'px'
+		@configDisplayScale()
+		return @
+
+	configDisplayScale: () ->
+		prevDisplayScale = @displayScale
+
+		if @options.highDpiSupport == false
+			delete @displayScale
+		else
+			devicePixelRatio = window.devicePixelRatio or 1
+			backingStorePixelRatio =
+				@ctx.webkitBackingStorePixelRatio or
+				@ctx.mozBackingStorePixelRatio or
+				@ctx.msBackingStorePixelRatio or
+				@ctx.oBackingStorePixelRatio or
+				@ctx.backingStorePixelRatio or 1
+			@displayScale = devicePixelRatio / backingStorePixelRatio
+
+		if @displayScale != prevDisplayScale
+			width = @canvas.G__width or @canvas.width
+			height = @canvas.G__height or @canvas.height
+			@canvas.width = width * @displayScale
+			@canvas.height = height * @displayScale
+			@canvas.style.width = "#{width}px"
+			@canvas.style.height = "#{height}px"
+			@canvas.G__width = width
+			@canvas.G__height = height
+
 		return @
 
 class TextRenderer


### PR DESCRIPTION
Currently gauge.js looks rather blurry on high-DPI displays such as retina macbooks, or the new kirabook from toshiba. This pull request uses the technique described at [html5rocks](http://www.html5rocks.com/en/tutorials/canvas/hidpi/) to achieve very sharp gauges on these displays as well.
-  [Before](https://f.cloud.github.com/assets/1258798/490110/872b5f0e-b9b0-11e2-8a2b-52f330dea20b.png)
-  [After](https://f.cloud.github.com/assets/1258798/490111/8c88ed2c-b9b0-11e2-94c6-4c4ecb86a4f9.png)

Note I did not commit the recompiled js-file as I was unsure if you would want me to. Let me know if I should add it.
