### PR TITLE
Tutorial update

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@ var opts = {
 };
 var target = document.getElementById('foo'); // your canvas element
 var gauge = new <span id="class-code-name" class="typ">Gauge</span>(target).setOptions(opts); // create sexy gauge!
-gauge.setTextField(document.getElementById('bar')); // an element where the current gauge value will display
+gauge.setTextField(document.getElementById('bar')); // an element to display the current gauge value
 gauge.maxValue = <span id="opt-maxval" class="lit">3000</span>; // set max gauge value
 gauge.animationSpeed = <span id="opt-animationSpeed" class="lit">3000</span>; // set animation speed (32 is default value)
 gauge.set(<span id="opt-currval" class="lit">1500</span>); // set actual value
@@ -114,6 +114,17 @@ gauge.set(<span id="opt-currval" class="lit">1500</span>); // set actual value
 <p>
   The <code>Gauge</code> class handles drawing on canvas and starts the animation. 
 </p>
+<h4>Notes:</h4>
+<ul>
+    <li>To convert values from the demo sliders into your <code>opts</code> dict,
+        <ul>
+            <li>divide <code>lineWidth</code>, <code>angle</code>, or <code>pointer.length</code> by 100</li>
+            <li>divide <code>pointer.strokeWidth</code> by 1,000</li>
+        </ul>
+    </li>
+    <li>There is no gauge.js setting for fontSize -- you're in charge of that.</li>
+    
+</ul>
 
 <h2 id="advanced-options">Advanced options</h2>
 <ul>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
   <li>No dependencies (jQuery is <a href="#jquery">supported</a>, but not required)</li>
   <li>Highly configurable</li>
   <li>Resolution independent</li>
-  <li>Animated guage value changes (!)</li>
+  <li>Animated gauge value changes (!)</li>
   <li>Works in all major browsers</li>
   <li>MIT License</li>
 </ul>
@@ -119,7 +119,7 @@ gauge.set(<span id="opt-currval" class="lit">1500</span>); // set actual value
 <ul>
   <li>
     <b>Percentage color</b>
-    <p>If you want to control how Gauge behavaes in relation to the displayed value you can use the Guage option called <b>percentColors</b>. To use it add following entry to the options:
+    <p>If you want to control how Gauge behavaes in relation to the displayed value you can use the Gauge option called <b>percentColors</b>. To use it add following entry to the options:
 <pre class="prettyprint">
 percentColors = [[0.0, "#a9d70b" ], [0.50, "#f9c802"], [1.0, "#ff0000"]];
 </pre>

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@ var opts = {
 };
 var target = document.getElementById('foo'); // your canvas element
 var gauge = new <span id="class-code-name" class="typ">Gauge</span>(target).setOptions(opts); // create sexy gauge!
+gauge.setTextField(document.getElementById('bar')); // an element where the current gauge value will display
 gauge.maxValue = <span id="opt-maxval" class="lit">3000</span>; // set max gauge value
 gauge.animationSpeed = <span id="opt-animationSpeed" class="lit">3000</span>; // set animation speed (32 is default value)
 gauge.set(<span id="opt-currval" class="lit">1500</span>); // set actual value


### PR DESCRIPTION
Three things:

* demonstrate the `setTextField()` function
* document a few gotchas for users translating the demo slider values to their opts dict values
* typo fixes