### PR TITLE
Add formatted value label to gauge via new value options.

### DIFF
--- a/dist/gauge.js
+++ b/dist/gauge.js
@@ -452,7 +452,16 @@
       radiusScale: 1.0,
       fontSize: 40,
       limitMax: false,
-      limitMin: false
+      limitMin: false,
+      value: {
+          show: true,
+          font: "20px Arial",
+          color: "black",
+          down: 0,
+          right: 0,
+          decimals: 0,
+          units: ""
+      }
     };
 
     function Gauge(canvas) {
@@ -759,6 +768,16 @@
         this.ctx.beginPath();
         this.ctx.arc(w, h, radius, displayedAngle, (2 - this.options.angle) * Math.PI, false);
         this.ctx.stroke();
+        if (this.options.value.show == true) {
+          this.ctx.globalCompositeOperation='destination-over';
+          this.ctx.font = this.options.value.font;
+          this.ctx.fillStyle = this.options.value.color;
+          this.ctx.textAlign = "center";
+          this.ctx.fillText(addCommas(
+            this.displayedValue.toFixed(this.options.value.decimals)) + " " + this.options.value.units, 
+            (this.canvas.width/2) + this.options.value.right, 
+            (this.canvas.height/2) + this.options.value.down);
+        }
         this.ctx.save();
         this.ctx.translate(w, h);
       }

--- a/dist/gauge.js
+++ b/dist/gauge.js
@@ -769,7 +769,6 @@
         this.ctx.arc(w, h, radius, displayedAngle, (2 - this.options.angle) * Math.PI, false);
         this.ctx.stroke();
         if (this.options.value.show == true) {
-          this.ctx.globalCompositeOperation='destination-over';
           this.ctx.font = this.options.value.font;
           this.ctx.fillStyle = this.options.value.color;
           this.ctx.textAlign = "center";


### PR DESCRIPTION
Options includes value with properties for displaying the value in the gauge using options specified including font, right, down, decimals, color and units.

This was added because using absolute position does not work well for placing text over the gauge.

**Note: gauge.min.js has not been modified.**